### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -76,7 +76,7 @@ routes.get('/ongs', createRateLimiter(), OngController.index);
 routes.post('/ongs', createRateLimiter(), celebrate(sessionSchema), OngController.create);
 routes.get('/profile', createRateLimiter(), celebrate(profileSchema), ProfileController.index);
 routes.get('/incidents', createRateLimiter(), celebrate(querySchema), IncidentController.index);
-routes.post('/incidents', celebrate(incidentSchema), IncidentController.create);
+routes.post('/incidents', createRateLimiter(), celebrate(incidentSchema), IncidentController.create);
 routes.delete('/incidents/:id', createRateLimiter(), celebrate(paramsSchema), IncidentController.delete);
 
 module.exports = routes;


### PR DESCRIPTION
Potential fix for [https://github.com/Pimenteldiego/OmniStack-11.0/security/code-scanning/14](https://github.com/Pimenteldiego/OmniStack-11.0/security/code-scanning/14)

To fix the problem, we need to apply rate limiting to the `IncidentController.create` route handler. This can be done by using the existing `createRateLimiter` function, which sets up a rate limiter with a maximum of 100 requests per 15 minutes. We will add this rate limiter to the `routes.post('/incidents', celebrate(incidentSchema), IncidentController.create)` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
